### PR TITLE
added support for `should` assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 From tslint 5, lint applies `no-unused-expression` more strictly. This affects
 test assertion written via [`chai`](http://chaijs.com/), as its `expect` assertion is form of expression caught by lint. `tslint-no-unused-expression-chai` provides drop-in replacement of rule `no-unused-expression` to loosen lint checker for chai's assertion.
 
-This module supports chai's `expect` based assertion (i.e `expect(x).to.be....`), while other type of property based assertion still may not work.
+This module supports chai's `expect` based assertion (i.e `expect(x).to.be....`).
+When adding `"should"` to the rule configuration, it also supports those assertios.
+Other type of property based assertion still may not work.
 
 # Install
 

--- a/src/noUnusedExpressionChaiRule.ts
+++ b/src/noUnusedExpressionChaiRule.ts
@@ -1,7 +1,43 @@
 import * as ts from 'typescript';
 import * as Lint from 'tslint';
 import * as tsutils from 'tsutils';
-import { Rule as BaseUnusedExpressionRule } from 'tslint/lib/rules/noUnusedExpressionRule';
+import {Rule as BaseUnusedExpressionRule} from 'tslint/lib/rules/noUnusedExpressionRule';
+
+const OPTION_SHOULD: 'should' = 'should';
+
+// START copied from noUnusedExpression.ts
+const ALLOW_FAST_NULL_CHECKS = 'allow-fast-null-checks';
+const ALLOW_NEW = 'allow-new';
+const ALLOW_TAGGED_TEMPLATE = 'allow-tagged-template';
+
+const TSLINT_META: Partial<Lint.IRuleMetadata> = {
+  optionsDescription: Lint.Utils.dedent`
+The following arguments may be optionally provided:
+
+* \`${ALLOW_FAST_NULL_CHECKS}\` allows to use logical operators to perform fast null checks
+  and perform method or function calls for side effects (e.g. \`e && e.preventDefault()\`).
+* \`${ALLOW_NEW}\` allows 'new' expressions for side effects (e.g. \`new ModifyGlobalState();\`.
+* \`${ALLOW_TAGGED_TEMPLATE}\` allows tagged templates for side effects
+  (e.g. \`this.add\\\`foo\\\`;\`).
+* \`${OPTION_SHOULD}\` supports chai assertions using \`should\` in addition to \`expect\`;\`.
+`,
+  options: {
+    type: 'array',
+    items: {
+      type: 'string',
+      enum: [ALLOW_FAST_NULL_CHECKS, ALLOW_NEW, ALLOW_TAGGED_TEMPLATE, OPTION_SHOULD]
+    },
+    minLength: 0,
+    maxLength: 4
+  },
+  optionExamples: [
+    true,
+    [true, ALLOW_FAST_NULL_CHECKS],
+    [true, OPTION_SHOULD],
+    [true, ALLOW_FAST_NULL_CHECKS, OPTION_SHOULD]
+  ]
+};
+// END copied from noUnusedExpression.ts
 
 /**
  * Predicate to determine given failure is chai's `expect` assertion.
@@ -73,6 +109,8 @@ const withoutShouldAssertions = (failure: Lint.RuleFailure, source: ts.SourceFil
  *
  */
 export class Rule extends BaseUnusedExpressionRule {
+
+  public static metadata = {...BaseUnusedExpressionRule.metadata, ...TSLINT_META};
   /**
    * Apply rules. Simply walk source by default rule first, and filter out chai expression
    *
@@ -80,9 +118,14 @@ export class Rule extends BaseUnusedExpressionRule {
   public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
     const failures: Lint.RuleFailure[] = super.apply(sourceFile);
     if (failures && failures.length > 0) {
-      return failures
-        .filter((x) => chaiAssertionPredicate(x, sourceFile))
-        .filter((x) => withoutShouldAssertions(x, sourceFile));
+      const filterShould = this.ruleArguments.indexOf(OPTION_SHOULD) > -1;
+      return failures.filter(x => {
+        const expectResult = chaiAssertionPredicate(x, sourceFile);
+        if (expectResult && filterShould) {
+          return withoutShouldAssertions(x, sourceFile);
+        }
+        return expectResult;
+      });
     }
 
     return failures;

--- a/src/noUnusedExpressionChaiRule.ts
+++ b/src/noUnusedExpressionChaiRule.ts
@@ -45,23 +45,21 @@ const withoutShouldAssertions = (failure: Lint.RuleFailure, source: ts.SourceFil
   const failurePosition = failure.getStartPosition();
   const token = tsutils.getTokenAtPosition(source, failurePosition.getPosition());
 
-  //for any reason locating token is not available, falls back to default rule
+  // for any reason locating token is not available, falls back to default rule
   if (!token) {
     return true;
   }
 
-  let last = token;
-  let current = token.parent;
+  let current: ts.Node | undefined = token;
   // scan through parents for a property access expression
   // stop when hitting expression statement
   while (current && !tsutils.isExpressionStatement(current)) {
     if (tsutils.isPropertyAccessExpression(current)) {
       if (current.name.text === 'should') {
         // make sure there is at least one more property access after should
-        return tsutils.isPropertyAccessExpression(last);
+        return current.parent && !tsutils.isPropertyAccessExpression(current.parent);
       }
     }
-    last = current;
     current = current.parent;
   }
 

--- a/test/allow-fast-null-checks/test.ts.lint
+++ b/test/allow-fast-null-checks/test.ts.lint
@@ -149,4 +149,16 @@ expect(NaN).to.be.NaN;
 expect(1).to.be.exist;
 expect(undefined).to.be.empty;
 
+tips.should.not.have.been.called;
+method().prop.fancy().should.work;
+method(whatever).prop.fancy('').should.work;
+method(undefined, null).prop.fancy(NaN).should.work;
+
+forgot.to.assert.should // there needs to be at least one more property access
+~~~~~~~~~~~~~~~~~~~~~~~ [0]
+should.not.work // should is not used as a property access
+~~~~~~~~~~~~~~~ [0]
+it.shouldnt.be.filtered.out; // typos are not acceptable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
 [0]: unused expression, expected an assignment or function call

--- a/test/allow-fast-null-checks/test.ts.lint
+++ b/test/allow-fast-null-checks/test.ts.lint
@@ -153,6 +153,8 @@ tips.should.not.have.been.called;
 method().prop.fancy().should.work;
 method(whatever).prop.fancy('').should.work;
 method(undefined, null).prop.fancy(NaN).should.work;
+method(whatever).prop.fancy('').other.should.work;
+devStore.subscribe.should.have.been.calledOnce;
 
 forgot.to.assert.should // there needs to be at least one more property access
 ~~~~~~~~~~~~~~~~~~~~~~~ [0]

--- a/test/allow-fast-null-checks/tslint.json
+++ b/test/allow-fast-null-checks/tslint.json
@@ -2,7 +2,8 @@
   "rules": {
     "no-unused-expression-chai": [
       true,
-      "allow-fast-null-checks"
+      "allow-fast-null-checks",
+      "should"
     ]
   },
   "rulesDirectory": [

--- a/test/allow-new/test.ts.lint
+++ b/test/allow-new/test.ts.lint
@@ -155,6 +155,8 @@ tips.should.not.have.been.called;
 method().prop.fancy().should.work;
 method(whatever).prop.fancy('').should.work;
 method(undefined, null).prop.fancy(NaN).should.work;
+method(whatever).prop.fancy('').other.should.work;
+devStore.subscribe.should.have.been.calledOnce;
 
 forgot.to.assert.should // there needs to be at least one more property access
 ~~~~~~~~~~~~~~~~~~~~~~~ [0]

--- a/test/allow-new/test.ts.lint
+++ b/test/allow-new/test.ts.lint
@@ -151,4 +151,16 @@ expect(NaN).to.be.NaN;
 expect(1).to.be.exist;
 expect(undefined).to.be.empty;
 
+tips.should.not.have.been.called;
+method().prop.fancy().should.work;
+method(whatever).prop.fancy('').should.work;
+method(undefined, null).prop.fancy(NaN).should.work;
+
+forgot.to.assert.should // there needs to be at least one more property access
+~~~~~~~~~~~~~~~~~~~~~~~ [0]
+should.not.work // should is not used as a property access
+~~~~~~~~~~~~~~~ [0]
+it.shouldnt.be.filtered.out; // typos are not acceptable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
 [0]: unused expression, expected an assignment or function call

--- a/test/allow-new/tslint.json
+++ b/test/allow-new/tslint.json
@@ -3,7 +3,8 @@
     "no-unused-expression-chai": [
       true,
       "allow-new",
-      "allow-fast-null-checks"
+      "allow-fast-null-checks",
+      "should"
     ]
   },
   "rulesDirectory": [

--- a/test/allow-tagged-template/test.ts.lint
+++ b/test/allow-tagged-template/test.ts.lint
@@ -200,4 +200,16 @@ expect(NaN).to.be.NaN;
 expect(1).to.be.exist;
 expect(undefined).to.be.empty;
 
+tips.should.not.have.been.called;
+method().prop.fancy().should.work;
+method(whatever).prop.fancy('').should.work;
+method(undefined, null).prop.fancy(NaN).should.work;
+
+forgot.to.assert.should // there needs to be at least one more property access
+~~~~~~~~~~~~~~~~~~~~~~~ [0]
+should.not.work // should is not used as a property access
+~~~~~~~~~~~~~~~ [0]
+it.shouldnt.be.filtered.out; // typos are not acceptable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
 [0]: unused expression, expected an assignment or function call

--- a/test/allow-tagged-template/test.ts.lint
+++ b/test/allow-tagged-template/test.ts.lint
@@ -204,6 +204,8 @@ tips.should.not.have.been.called;
 method().prop.fancy().should.work;
 method(whatever).prop.fancy('').should.work;
 method(undefined, null).prop.fancy(NaN).should.work;
+method(whatever).prop.fancy('').other.should.work;
+devStore.subscribe.should.have.been.calledOnce;
 
 forgot.to.assert.should // there needs to be at least one more property access
 ~~~~~~~~~~~~~~~~~~~~~~~ [0]

--- a/test/allow-tagged-template/tslint.json
+++ b/test/allow-tagged-template/tslint.json
@@ -2,7 +2,8 @@
   "rules": {
     "no-unused-expression-chai": [
       true,
-      "allow-tagged-template"
+      "allow-tagged-template",
+      "should"
     ]
   },
   "rulesDirectory": [

--- a/test/default/test.ts.lint
+++ b/test/default/test.ts.lint
@@ -232,4 +232,16 @@ expect(NaN).to.be.NaN;
 expect(1).to.be.exist;
 expect(undefined).to.be.empty;
 
+tips.should.not.have.been.called;
+method().prop.fancy().should.work;
+method(whatever).prop.fancy('').should.work;
+method(undefined, null).prop.fancy(NaN).should.work;
+
+forgot.to.assert.should // there needs to be at least one more property access
+~~~~~~~~~~~~~~~~~~~~~~~ [0]
+should.not.work // should is not used as a property access
+~~~~~~~~~~~~~~~ [0]
+it.shouldnt.be.filtered.out; // typos are not acceptable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
+
 [0]: unused expression, expected an assignment or function call

--- a/test/default/test.ts.lint
+++ b/test/default/test.ts.lint
@@ -236,6 +236,8 @@ tips.should.not.have.been.called;
 method().prop.fancy().should.work;
 method(whatever).prop.fancy('').should.work;
 method(undefined, null).prop.fancy(NaN).should.work;
+method(whatever).prop.fancy('').other.should.work;
+devStore.subscribe.should.have.been.calledOnce;
 
 forgot.to.assert.should // there needs to be at least one more property access
 ~~~~~~~~~~~~~~~~~~~~~~~ [0]

--- a/test/should/test.ts.lint
+++ b/test/should/test.ts.lint
@@ -233,17 +233,11 @@ expect(1).to.be.exist;
 expect(undefined).to.be.empty;
 
 tips.should.not.have.been.called;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
 method().prop.fancy().should.work;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
 method(whatever).prop.fancy('').should.work;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
 method(undefined, null).prop.fancy(NaN).should.work;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
 method(whatever).prop.fancy('').other.should.work;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
 devStore.subscribe.should.have.been.calledOnce;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [0]
 
 forgot.to.assert.should // there needs to be at least one more property access
 ~~~~~~~~~~~~~~~~~~~~~~~ [0]

--- a/test/should/tslint.json
+++ b/test/should/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "no-unused-expression-chai": [true, "should"]
+  },
+  "rulesDirectory": [
+    "../../rules"
+  ]
+}


### PR DESCRIPTION
an additional filter is used after the one for expect, to look for should

fixes #9 

Please let me know what you think, or if something is missing.

PS: I looked at [the linted snipptes in AST Explorer](https://astexplorer.net/#/gist/9a3ca20c0154c89b1a5bd092337eb2e0/7d0f74a676f085f28bba9bbcda2b8d1830bd878c) to come up with the solution.